### PR TITLE
add workspace configuration settings and ruleset/ignore file commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,30 @@ The extension uses the `vacuum` executable installed on your machine. If VSCode 
 To configure vacuum to use your own rules, rulesets and custom functions, you can 
 [provide a configuration file](https://quobix.com/vacuum/configuring).
 
-To change the configuration, you will need to disable and re-enable vacuum.
+You can also configure the extension from VS Code:
+
+1. Open the command palette.
+2. Run `Select vacuum Ruleset` or `Select vacuum Ignore File`.
+3. Pick the ruleset or ignore file to save it into the workspace settings.
+
+The extension supports these workspace settings:
+
+```json
+{
+  "vacuum.ruleset": "path/to/ruleset.yaml",
+  "vacuum.ignoreFile": "path/to/ignore.yaml",
+  "vacuum.functions": "path/to/functions",
+  "vacuum.base": "path/to/api/root",
+  "vacuum.remote": true,
+  "vacuum.skipCheck": false,
+  "vacuum.timeout": 5,
+  "vacuum.lookupTimeout": 500,
+  "vacuum.hardMode": false,
+  "vacuum.extensionRefs": false
+}
+```
+
+Configuration changes are sent to the running language server and open documents are linted again automatically.
 
 ### Documentation
 
@@ -56,5 +79,4 @@ Learn more about vacuum by visiting the [vacuum documentation](https://quobix.co
 
 [vacuum documentation](https://quobix.com/vacuum/)
 [vacuum online demo](https://quobix.com/vacuum/demo)
-
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,22 @@
       {
         "command": "vacuum.stopLint",
         "title": "Stop Linting OpenAPI using vacuum"
+      },
+      {
+        "command": "vacuum.selectRuleset",
+        "title": "Select vacuum Ruleset"
+      },
+      {
+        "command": "vacuum.clearRuleset",
+        "title": "Clear vacuum Ruleset"
+      },
+      {
+        "command": "vacuum.selectIgnoreFile",
+        "title": "Select vacuum Ignore File"
+      },
+      {
+        "command": "vacuum.clearIgnoreFile",
+        "title": "Clear vacuum Ignore File"
       }
     ],
     "configuration": {
@@ -45,7 +61,100 @@
         "vacuum.executablePath": {
           "type": "string",
           "default": "",
+          "scope": "machine-overridable",
           "description": "Path to the vacuum executable. Leave empty to auto-detect vacuum on PATH."
+        },
+        "vacuum.ruleset": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Path or URL to a custom vacuum or Spectral-compatible ruleset."
+        },
+        "vacuum.ignoreFile": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Path to a vacuum ignore file."
+        },
+        "vacuum.functions": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Path to custom vacuum function definitions."
+        },
+        "vacuum.base": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Base URL or path to use for resolving local and remote references."
+        },
+        "vacuum.remote": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Allow local files and remote HTTP references to be resolved."
+        },
+        "vacuum.skipCheck": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Skip OpenAPI document validation before linting."
+        },
+        "vacuum.timeout": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "minimum": 1,
+          "scope": "resource",
+          "description": "Rule execution timeout in seconds."
+        },
+        "vacuum.lookupTimeout": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "minimum": 1,
+          "scope": "resource",
+          "description": "JSONPath node lookup timeout in milliseconds."
+        },
+        "vacuum.hardMode": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Enable all built-in rules, including OWASP rules."
+        },
+        "vacuum.extensionRefs": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "Resolve $ref values inside extension objects."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,13 @@ import {
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
-  } from 'vscode-languageclient/node';
+} from 'vscode-languageclient/node';
 
 const configSection = 'vacuum';
 const enabledSetting = 'languageServer.enabled';
 const executablePathSetting = 'executablePath';
+const rulesetSetting = 'ruleset';
+const ignoreFileSetting = 'ignoreFile';
 const isWindows = os.platform() === 'win32';
 
 let lspClient: LanguageClient | undefined;
@@ -36,6 +38,20 @@ export function activate(context: vscode.ExtensionContext) {
 		await stopLanguageServer();
 		vscode.window.showInformationMessage('vacuum has stopped linting your yaml/json files.');
 	});
+	const selectRuleset = vscode.commands.registerCommand('vacuum.selectRuleset', async () => {
+		await selectWorkspaceFileSetting(rulesetSetting, 'Select vacuum ruleset');
+	});
+	const clearRuleset = vscode.commands.registerCommand('vacuum.clearRuleset', async () => {
+		await clearWorkspaceSetting(rulesetSetting);
+		vscode.window.showInformationMessage('vacuum ruleset setting cleared.');
+	});
+	const selectIgnoreFile = vscode.commands.registerCommand('vacuum.selectIgnoreFile', async () => {
+		await selectWorkspaceFileSetting(ignoreFileSetting, 'Select vacuum ignore file');
+	});
+	const clearIgnoreFile = vscode.commands.registerCommand('vacuum.clearIgnoreFile', async () => {
+		await clearWorkspaceSetting(ignoreFileSetting);
+		vscode.window.showInformationMessage('vacuum ignore file setting cleared.');
+	});
 
 	const configWatcher = vscode.workspace.onDidChangeConfiguration(async (event) => {
 		if (!event.affectsConfiguration(`${configSection}.${enabledSetting}`) &&
@@ -49,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	context.subscriptions.push(lint, stopLint, configWatcher);
+	context.subscriptions.push(lint, stopLint, selectRuleset, clearRuleset, selectIgnoreFile, clearIgnoreFile, configWatcher);
 
 	if (isLanguageServerEnabled()) {
 		void startLanguageServer(false);
@@ -129,6 +145,92 @@ function getVacuumConfiguration(): vscode.WorkspaceConfiguration {
 
 function getConfigurationScope(): vscode.ConfigurationScope | undefined {
 	return vscode.window.activeTextEditor?.document ?? vscode.workspace.workspaceFolders?.[0];
+}
+
+async function selectWorkspaceFileSetting(setting: string, title: string): Promise<void> {
+	const workspaceFolder = await resolveWorkspaceFolderForUpdate();
+	if (workspaceFolder === null) {
+		return;
+	}
+	const defaultUri = workspaceFolder?.uri;
+	const selection = await vscode.window.showOpenDialog({
+		title,
+		defaultUri,
+		canSelectFiles: true,
+		canSelectFolders: false,
+		canSelectMany: false,
+		openLabel: 'Select',
+		filters: {
+			'YAML, JSON': ['yaml', 'yml', 'json'],
+			'All Files': ['*'],
+		},
+	});
+
+	if (!selection || selection.length === 0) {
+		return;
+	}
+
+	await updateWorkspaceSetting(setting, valueForWorkspaceSetting(selection[0], workspaceFolder), workspaceFolder);
+	vscode.window.showInformationMessage(`vacuum ${setting} setting updated.`);
+}
+
+async function updateWorkspaceSetting(
+	setting: string,
+	value: string | undefined,
+	workspaceFolder?: vscode.WorkspaceFolder
+): Promise<void> {
+	const configuration = vscode.workspace.getConfiguration(configSection, workspaceFolder);
+	const target = workspaceFolder
+		? vscode.ConfigurationTarget.WorkspaceFolder
+		: vscode.ConfigurationTarget.Global;
+
+	await configuration.update(setting, value, target);
+}
+
+async function clearWorkspaceSetting(setting: string): Promise<void> {
+	const workspaceFolder = await resolveWorkspaceFolderForUpdate();
+	if (workspaceFolder === null) {
+		return;
+	}
+	await updateWorkspaceSetting(setting, undefined, workspaceFolder);
+}
+
+async function resolveWorkspaceFolderForUpdate(): Promise<vscode.WorkspaceFolder | undefined | null> {
+	const activeResource = vscode.window.activeTextEditor?.document.uri;
+	if (activeResource) {
+		const activeFolder = vscode.workspace.getWorkspaceFolder(activeResource);
+		if (activeFolder) {
+			return activeFolder;
+		}
+	}
+
+	const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
+	if (workspaceFolders.length <= 1) {
+		return workspaceFolders[0];
+	}
+
+	const selection = await vscode.window.showQuickPick(
+		workspaceFolders.map((folder) => ({ label: folder.name, folder })),
+		{ placeHolder: 'Select the workspace folder for the vacuum setting' }
+	);
+	return selection?.folder ?? null;
+}
+
+function valueForWorkspaceSetting(uri: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder | undefined): string {
+	if (uri.scheme !== 'file') {
+		return uri.toString();
+	}
+
+	if (!workspaceFolder || workspaceFolder.uri.scheme !== 'file') {
+		return uri.fsPath;
+	}
+
+	const relative = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
+	if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+		return relative.split(path.sep).join('/');
+	}
+
+	return uri.fsPath;
 }
 
 function getLanguageServerEnabledUpdateScope(configuration: vscode.WorkspaceConfiguration): ConfigurationUpdateScope {


### PR DESCRIPTION
Add resource-scoped settings (ruleset, ignoreFile, functions, base, remote, skipCheck, timeout, lookupTimeout, hardMode, extensionRefs) and mark executablePath as machine-overridable.

Register Select/Clear commands for the ruleset and ignore file that write paths into workspace settings, storing workspace-relative paths where possible.

Document the new settings and command palette workflow in the README.